### PR TITLE
Add -c to use custom editor command.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ MVim
 
 MVim is a small tool to rename or move files by editing their names with vim.
 
+.. image:: https://asciinema.org/a/Z6JVSnX0noQxZULZhSKdc5k5n.png
+   :target: https://asciinema.org/a/Z6JVSnX0noQxZULZhSKdc5k5n
+
 Known issues
 ------------
 

--- a/bin/mvim
+++ b/bin/mvim
@@ -18,6 +18,10 @@ if __name__ == "__main__":
                         action='store_true',
                         help='remove directories and their contents '
                         'recursively.')
+    parser.add_argument('-w', '--windows', dest='windows', action='store_true',
+                        help='open old and new filenames in two windows side by side.')
+    parser.add_argument('-d', '--diff', dest='diff', action='store_true',
+                        help='same as -w but in diff mode.')
     parser.add_argument('files', metavar='FILE', nargs='*', help='file or '
                         'directory to rename')
 
@@ -31,4 +35,6 @@ if __name__ == "__main__":
          all_files=args.all_files,
          follow_symlinks=args.follow_symlinks,
          force=args.force,
-         recursive=args.recursive)
+         recursive=args.recursive,
+         windows=args.windows,
+         diff=args.diff)

--- a/bin/mvim
+++ b/bin/mvim
@@ -22,6 +22,8 @@ if __name__ == "__main__":
                         help='open old and new filenames in two windows side by side.')
     parser.add_argument('-d', '--diff', dest='diff', action='store_true',
                         help='same as -w but in diff mode.')
+    parser.add_argument('-m', '--meld', dest='meld', action='store_true',
+                        help='same as -d but open with meld.')
     parser.add_argument('files', metavar='FILE', nargs='*', help='file or '
                         'directory to rename')
 
@@ -31,10 +33,4 @@ if __name__ == "__main__":
     if not files:
         files.append('.')
 
-    MVim(args.files,
-         all_files=args.all_files,
-         follow_symlinks=args.follow_symlinks,
-         force=args.force,
-         recursive=args.recursive,
-         windows=args.windows,
-         diff=args.diff)
+    MVim(**vars(args))

--- a/bin/mvim
+++ b/bin/mvim
@@ -24,6 +24,8 @@ if __name__ == "__main__":
                         help='same as -w but in diff mode.')
     parser.add_argument('-m', '--meld', dest='meld', action='store_true',
                         help='same as -d but open with meld.')
+    parser.add_argument('-c', '--command', dest='cmd', default=None,
+                        help='use custom editor command (can be combined with -d).')
     parser.add_argument('files', metavar='FILE', nargs='*', help='file or '
                         'directory to rename')
 

--- a/mvim/mvim.py
+++ b/mvim/mvim.py
@@ -24,7 +24,15 @@ from shutil import rmtree
 
 class MVim:
 
-    def __init__(self, files, **kwargs):
+    def __init__(self, files, *, all_files=False, follow_symlinks=False,
+                 force=False, recursive=False, windows=False, diff=False, meld=False):
+
+        self.all_files = all_files
+        self.follow_symlinks = follow_symlinks
+        self.force = force
+        self.recursive = recursive
+        self.windows = windows
+        self.diff = diff
 
         self.all_files = False # do not ignore entires startinng with .
         self.follow_symlinks = False
@@ -60,7 +68,7 @@ class MVim:
         self.save_names_to_tmp(self.oldnames, self.new_names_file)
 
         # Create a temporary file with old filenames if necessary.
-        if self.windows or self.diff:
+        if self.windows or self.diff or self.meld:
             self.old_names_file = NamedTemporaryFile(prefix='mvim.oldnames.')
             self.save_names_to_tmp(self.oldnames, self.old_names_file)
 
@@ -142,6 +150,12 @@ class MVim:
                 '-c', 'set splitright',
                 '-c', 'vsp',
                 '-c', 'edit ' + self.new_names_file.name
+            ])
+        elif self.meld:
+            subprocess.call([
+                'meld',
+                self.old_names_file.name,
+                self.new_names_file.name,
             ])
         else:
             subprocess.call(['vim', self.new_names_file.name])

--- a/mvim/mvim.py
+++ b/mvim/mvim.py
@@ -33,28 +33,7 @@ class MVim:
         self.recursive = recursive
         self.windows = windows
         self.diff = diff
-
-        self.all_files = False # do not ignore entires startinng with .
-        self.follow_symlinks = False
-        self.force = False # force remove without asking
-        self.recursive = False # recursively remove directory
-
-        for arg in kwargs:
-            if arg == 'all_files':
-                self.all_files = kwargs[arg]
-            elif arg == 'follow_symlinks':
-                self.follow_symlinks = kwargs[arg]
-            elif arg == 'force':
-                self.force = kwargs[arg]
-            elif arg == 'recursive':
-                self.recursive = kwargs[arg]
-            elif arg == 'windows':
-                self.windows = kwargs[arg]
-            elif arg == 'diff':
-                self.diff = kwargs[arg]
-            else:
-                print("Warning: ignoring invalid option '%s'" %arg,
-                        file=sys.stdout)
+        self.meld = meld
 
         self.oldnames = []
         self.added_dir = []


### PR DESCRIPTION
On its own opens an editor with newnames file as the single argument.
In combination with `-d` passes oldnames as the first and newnames as the second argument.
Also reimplements `-m` as `-dc meld` shortcut.